### PR TITLE
fix: src/logic/isNumber.js is not matching number properly

### DIFF
--- a/src/logic/isNumber.js
+++ b/src/logic/isNumber.js
@@ -1,3 +1,3 @@
 export default function isNumber(item) {
-  return /[0-9]/.test(item);
+  return /^[0-9]+$/.test(item);
 }


### PR DESCRIPTION
the original regex matches anything that consists of one digit. I add + for one or more occurrence of [0-9]. And ^ for start and $ for end of the search of the regex