### PR TITLE
fix: AC button does not work

### DIFF
--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -13,6 +13,14 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
+  if (buttonName === "AC") {
+    return {
+      total: null,
+      next: null,
+      operation: null,
+    };
+  }
+
   if (isNumber(buttonName)) {
     if (buttonName === "0" && obj.next === "0") {
       return {};


### PR DESCRIPTION
there is no logic for when the buttonName is AC. So I created one by adding an If condition which returns a Calculator data object containing total: null, next: null, operation: null. This thereby resets everything